### PR TITLE
Implement lazy Firebase initialization

### DIFF
--- a/frontend/peerprep-web/src/lib/firebase.ts
+++ b/frontend/peerprep-web/src/lib/firebase.ts
@@ -1,10 +1,25 @@
-import { initializeApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
+import { initializeApp, type FirebaseApp } from "firebase/app";
+import { getAuth, type Auth } from "firebase/auth";
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FB_API_KEY,
   authDomain: import.meta.env.VITE_FB_AUTH_DOMAIN,
   projectId: import.meta.env.VITE_FB_PROJECT_ID,
 };
-export const fbApp = initializeApp(firebaseConfig);
-export const fbAuth = getAuth(fbApp);
+
+let fbApp: FirebaseApp | null = null;
+let fbAuth: Auth | null = null;
+
+export function getFirebaseApp() {
+  if (!fbApp) {
+    fbApp = initializeApp(firebaseConfig);
+  }
+  return fbApp;
+}
+
+export function getFirebaseAuth() {
+  if (!fbAuth) {
+    fbAuth = getAuth(getFirebaseApp());
+  }
+  return fbAuth;
+}

--- a/frontend/peerprep-web/src/pages/Login.tsx
+++ b/frontend/peerprep-web/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { signInWithEmailAndPassword } from "firebase/auth";
-import { fbAuth } from "../lib/firebase";
+import { getFirebaseAuth } from "../lib/firebase";
 import { Link } from "react-router-dom";
 
 export default function Login() {
@@ -12,7 +12,7 @@ export default function Login() {
     e.preventDefault();
     setErr(null);
     try {
-      const cred = await signInWithEmailAndPassword(fbAuth, email, password);
+      const cred = await signInWithEmailAndPassword(getFirebaseAuth(), email, password);
 
       // exchange Firebase ID token for a server session cookie
       const idToken = await cred.user.getIdToken(/* forceRefresh? */ true);

--- a/frontend/peerprep-web/src/pages/Register.tsx
+++ b/frontend/peerprep-web/src/pages/Register.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { createUserWithEmailAndPassword, sendEmailVerification } from "firebase/auth";
-import { fbAuth } from "../lib/firebase";
+import { getFirebaseAuth } from "../lib/firebase";
 
 export default function Register() {
   const [email, setEmail] = useState("");
@@ -12,7 +12,7 @@ export default function Register() {
     setErr(null);
     try {
       // 1) Create Firebase user
-      const cred = await createUserWithEmailAndPassword(fbAuth, email, password);
+      const cred = await createUserWithEmailAndPassword(getFirebaseAuth(), email, password);
 
       // 2) Send verification email (optional to block here)
       await sendEmailVerification(cred.user);


### PR DESCRIPTION
Firebase is now initialized on-demand when authentication methods are called, preventing invalid API key errors on app startup. This change improves startup performance and only loads Firebase dependencies when actually needed for login/register operations.